### PR TITLE
Change git clone instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It includes both code running within iobroker and as vis widget. If you only pla
 
 ##Steps 
 1. download and unpack this packet from github ```https://github.com/ioBroker/ioBroker.template/archive/master.zip```
-  or clone git repository ```git clone https://github.com/ioBroker/ioBroker.template.git```
+  or clone git repository ```git clone --depth=1 https://github.com/ioBroker/ioBroker.template.git```
 
 2. download required npm packets. Write in ioBroker.template directory:
 


### PR DESCRIPTION
With the option `--depth=1`, `git clone` only includes the most recent commit in the history. This way, new adapters created by cloning don't get the entire history of the adapter repo.