### PR TITLE
'Error: EPERM: operation not permitted' on Windows because sequence of renames in gulpfile.js is wrong

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -406,12 +406,6 @@ gulp.task('rename', function ()  {
         fs.renameSync(__dirname + '/widgets/template.html',           __dirname + '/widgets/' + newname + '.html');
     }
     if (fs.existsSync(__dirname + '/widgets/template/js/template.js')) {
-        if (!fs.existsSync(__dirname + '/widgets/' + newname + '/')) {
-            fs.mkdirSync(__dirname + '/widgets/' + newname + '/');
-        }
-        if (!fs.existsSync(__dirname + '/widgets/' + newname + '/js/')) {
-            fs.mkdirSync(__dirname + '/widgets/' + newname + '/js/');
-        }        
         fs.renameSync(__dirname + '/widgets/template/js/template.js', __dirname + '/widgets/template/js/' + newname + '.js');
     }
     if (fs.existsSync(__dirname + '/widgets/template')) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -412,7 +412,7 @@ gulp.task('rename', function ()  {
         if (!fs.existsSync(__dirname + '/widgets/' + newname + '/js/')) {
             fs.mkdirSync(__dirname + '/widgets/' + newname + '/js/');
         }        
-        fs.renameSync(__dirname + '/widgets/template/js/template.js', __dirname + '/widgets/' + newname + '/js/' + newname + '.js');
+        fs.renameSync(__dirname + '/widgets/template/js/template.js', __dirname + '/widgets/template/js/' + newname + '.js');
     }
     if (fs.existsSync(__dirname + '/widgets/template')) {
         fs.renameSync(__dirname + '/widgets/template',                __dirname + '/widgets/' + newname);


### PR DESCRIPTION
Please check this. Thanks.