### PR TITLE
Update main.js

### DIFF
--- a/JavaScript/main.js
+++ b/JavaScript/main.js
@@ -17,10 +17,7 @@ class Template extends utils.Adapter {
      * @param {Partial<ioBroker.AdapterOptions>} [options={}]
      */
     constructor(options) {
-        super({
-            ...options,
-            name: 'template',
-        });
+        super( Object.assign({name: 'template'}, options) );
         this.on('ready', this.onReady.bind(this));
         this.on('objectChange', this.onObjectChange.bind(this));
         this.on('stateChange', this.onStateChange.bind(this));


### PR DESCRIPTION
spread-operator (...) leads to syntax error with npm 6:

super({
    ...options,                  // SyntaxError: Unexpected token ...
    name: "template",
});

replaced with

super( Object.assign({name: "template"}, options) );

works.